### PR TITLE
Add support for modular build structure. (#389)

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,46 @@
+# Copyright René Ferdinand Rivera Morell 2024
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+require-b2 5.2 ;
+
+import feature : feature ;
+
+feature boost.process.fs : boost std : optional propagated ;
+
+constant boost_dependencies :
+    /boost/algorithm//boost_algorithm
+    /boost/asio//boost_asio
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/fusion//boost_fusion
+    /boost/io//boost_io
+    /boost/iterator//boost_iterator
+    /boost/move//boost_move
+    /boost/optional//boost_optional
+    /boost/system//boost_system
+    /boost/throw_exception//boost_throw_exception
+    /boost/tokenizer//boost_tokenizer
+    /boost/type_index//boost_type_index
+    /boost/type_traits//boost_type_traits
+    /boost/utility//boost_utility
+    /boost/winapi//boost_winapi ;
+
+project /boost/process
+    : common-requirements
+        <include>include
+    : default-build
+        <boost.process.fs>boost
+    ;
+
+explicit
+    [ alias boost_process : build//boost_process ]
+    [ alias all : boost_process example example/v2 test ]
+    ;
+
+call-if : boost-library process
+    : install boost_process
+    ;
+

--- a/build/Jamfile
+++ b/build/Jamfile
@@ -5,7 +5,8 @@
 
 import os ;
 import feature ;
-import ../../config/checks/config : requires ;
+import-search /boost/config/checks ;
+import config : requires ;
 
 project : requirements
   <define>BOOST_ASIO_NO_DEPRECATED
@@ -15,10 +16,10 @@ project : requirements
   <target-os>windows:<define>WIN32_LEAN_AND_MEAN
   <target-os>linux:<linkflags>-lpthread
   : source-location ../src
+  : common-requirements
+    <library>$(boost_dependencies)
+    <boost.process.fs>std:<define>BOOST_PROCESS_USE_STD_FS=1
 ;
-
-feature.feature boost.process.fs : boost std : propagated composite ;
-feature.compose <boost.process.fs>std : <define>BOOST_PROCESS_USE_STD_FS=1 ;
 
 alias process_sources
    : detail/environment_posix.cpp
@@ -40,26 +41,21 @@ alias process_sources
      shell.cpp
    ;
 
-if [ os.name ] = NT
-{
-  lib shell32 ;
-  lib advapi32 ;
-  lib ntdll ;
-  lib user32 ;
-  explicit shell32 advapi32 ntdll user32 ;
-}
+lib shell32 ;
+lib advapi32 ;
+lib ntdll ;
+lib user32 ;
 
 lib boost_process
    : process_sources
    : requirements <define>BOOST_PROCESS_SOURCE=1
      <link>shared:<define>BOOST_PROCESS_DYN_LINK=1
-     <boost.process.fs>boost:<library>/boost//filesystem
+     <boost.process.fs>boost:<library>/boost/filesystem//boost_filesystem
      <target-os>windows:<library>shell32
      <target-os>windows:<library>user32
      <target-os>windows:<library>ntdll
      <target-os>windows:<library>advapi32
    : usage-requirements
      <link>shared:<define>BOOST_PROCESS_DYN_LINK=1
+     <boost.process.fs>boost:<library>/boost/filesystem//boost_filesystem
   ;
-
-boost-install boost_process ;

--- a/doc/Jamfile.jam
+++ b/doc/Jamfile.jam
@@ -19,12 +19,12 @@ install images_glob : $(images) : <location>$(BOOST_ROOT)/doc/html/boost_process
 import type ;
 type.register XMLPROCESSWORKAROUND : : XML ;
 import generators ;
-generators.register-standard common.copy : XML : XMLPROCESSWORKAROUND ; 
+generators.register-standard common.copy : XML : XMLPROCESSWORKAROUND ;
 
 xmlprocessworkaround posix_pseudocode   : v1/posix_pseudocode.xml   ;
 xmlprocessworkaround windows_pseudocode : v1/windows_pseudocode.xml ;
 
-path-constant INCLUDES : ../../.. ;
+path-constant INCLUDES : ../include ;
 
 doxygen reference_v1
 :
@@ -66,7 +66,7 @@ doxygen reference_v2
     BOOST_PROCESS_V2_INITFN_AUTO_RESULT_TYPE(x,y)=deduced \\
     BOOST_PROCESS_V2_COMPLETION_TOKEN_FOR(X)=Token \\
     BOOST_PROCESS_V2_DEFAULT_COMPLETION_TOKEN_TYPE(E)=DEFAULT_TYPE \\
-    BOOST_ASIO_DEFAULT_COMPLETION_TOKEN=DEFAULT \\ 
+    BOOST_ASIO_DEFAULT_COMPLETION_TOKEN=DEFAULT \\
     BOOST_CONSTEXPR=constexpr \\
     BOOST_CXX14_CONSTEXPR=constexpr \\
     BOOST_PROCESS_V2_INLINE= \\
@@ -98,7 +98,7 @@ boostbook standalone
 ###############################################################################
 alias boostdoc
     : standalone/<format>docbook
-    : 
+    :
     : <dependency>images_glob
     : ;
 explicit boostdoc ;

--- a/example/Jamfile.jam
+++ b/example/Jamfile.jam
@@ -8,7 +8,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 project : requirements
-  <include>../../..
+  <library>/boost/process//boost_process
   <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS
   <target-os>windows:<define>WIN32_LEAN_AND_MEAN
 ;

--- a/example/v2/Jamfile.jam
+++ b/example/v2/Jamfile.jam
@@ -4,14 +4,12 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 project : requirements
-  <include>../../..
   <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS
   <target-os>windows:<define>WIN32_LEAN_AND_MEAN
+  <link>static
 ;
 
 import testing ;
 
-alias filesystem   : /boost//filesystem : <link>static ;
-
-exe intro : intro.cpp filesystem ;
-exe intro_popen : intro_popen.cpp filesystem ;
+exe intro : intro.cpp ;
+exe intro_popen : intro_popen.cpp : <boost.process.fs>boost ;

--- a/test/v1/Jamfile.jam
+++ b/test/v1/Jamfile.jam
@@ -9,17 +9,13 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 
-import os ;
-
-if [ os.name ] = NT
-{
-  lib ws2_32 ;
-  lib shell32 ;
-  lib Advapi32 ;
-  lib Ntdll ;
-}
+lib ws2_32 ;
+lib shell32 ;
+lib Advapi32 ;
+lib Ntdll ;
 
 project : requirements
+  <library>/boost/process//boost_process
   <define>BOOST_ASIO_NO_DEPRECATED
   <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS
   <toolset>msvc:<define>_CRT_SECURE_NO_DEPRECATE
@@ -28,6 +24,7 @@ project : requirements
   <target-os>linux:<linkflags>-lpthread
   <os>NT,<toolset>cw:<library>ws2_32
   <os>NT,<toolset>gcc:<library>ws2_32
+  <library>/boost/test//included
 ;
 
 
@@ -35,16 +32,19 @@ project : requirements
 import testing ;
 
 
-alias program_options  : /boost//program_options : <link>static ;
-alias filesystem       : /boost//filesystem      ;
-alias iostreams        : /boost//iostreams       ;
-alias system           : /boost//system          ;
-alias thread           : /boost//thread          ;
-alias coroutine        : /boost//coroutine       : <link>static ;
+alias program_options  : usage-requirements <library>/boost/program_options//boost_program_options ;
+alias filesystem       : usage-requirements <library>/boost/filesystem//boost_filesystem ;
+alias iostreams        : usage-requirements <library>/boost/iostreams//boost_iostreams ;
+alias system           : usage-requirements <library>/boost/system//boost_system ;
+alias thread           : usage-requirements <library>/boost/thread//boost_thread ;
+alias coroutine        : usage-requirements <library>/boost/coroutine//boost_coroutine ;
+alias scope_exit       : usage-requirements <library>/boost/scope_exit//boost_scope_exit ;
+alias lambda           : usage-requirements <library>/boost/lambda//boost_lambda ;
+alias chrono           : usage-requirements <library>/boost/chrono//boost_chrono ;
 
 lib multi_ref : multi_ref1.cpp multi_ref2.cpp system : <target-os>windows:<source>shell32 ;
 
-exe sparring_partner : sparring_partner.cpp program_options system filesystem iostreams :
+exe sparring_partner : sparring_partner.cpp program_options system filesystem iostreams lambda :
     <warnings>off <target-os>windows:<source>shell32 <target-os>windows:<source>Ntdll
     ;
 
@@ -100,15 +100,15 @@ test-suite with-valgrind :
     [ run env.cpp     program_options system filesystem       : [ test-options env ] : sparring_partner ]
     [ run group.cpp     system thread filesystem              : [ test-options group ] : sub_launch ]
     [ run group.cpp          system thread filesystem         : [ test-options group ] : sub_launch : <build>no <target-os>windows:<build>yes <define>BOOST_USE_WINDOWS_H=1 : group-windows-h ]
-    [ run group_wait.cpp     system thread filesystem         : [ test-options group_wait ] : sparring_partner : <target-os>darwin:<build>no <target-os>freebsd:<build>no ]
+    [ run group_wait.cpp system thread filesystem scope_exit  : [ test-options group_wait ] : sparring_partner : <target-os>darwin:<build>no <target-os>freebsd:<build>no ]
 	[ run limit_fd.cpp     program_options system filesystem  : [ test-options limit_fd ] : sparring_partner : <target-os>freebsd:<build>no ]
     [ run run_exe.cpp filesystem                              : : sparring_partner ]
     [ run run_exe_path.cpp filesystem                         : [ test-options run_exe_path ] : sparring_partner ]
     [ run search_path.cpp filesystem system                   : [ test-options search_path ] : : <target-os>windows:<source>shell32 ]
     [ run shell.cpp filesystem system                         : [ test-options shell ] : sparring_partner : <target-os>darwin:<build>no ]
     [ run shell_path.cpp  filesystem system                   : [ test-options shell_path ] ]
-    [ run system_test1.cpp filesystem system                  : [ test-options system_test1 ] : sparring_partner ]
-    [ run system_test2.cpp filesystem system                  : [ test-options system_test2 ] : sparring_partner ]
+    [ run system_test1.cpp filesystem system chrono           : [ test-options system_test1 ] : sparring_partner ]
+    [ run system_test2.cpp filesystem system chrono           : [ test-options system_test2 ] : sparring_partner ]
     [ run spawn.cpp filesystem system                         : [ test-options spawn ] : sparring_partner ]
     [ run start_dir.cpp   filesystem system                   : [ test-options start_dir ] : sparring_partner ]
     [ run terminate.cpp system filesystem                     : [ test-options terminate ] : sparring_partner : <target-os>freebsd:<build>no ]

--- a/test/v2/Jamfile.jam
+++ b/test/v2/Jamfile.jam
@@ -4,19 +4,15 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 
-import os ;
-
-if [ os.name ] = NT
-{
-  lib ws2_32 ;
-  lib shell32 ;
-  lib Advapi32 ;
-  lib Ntdll ;
-  lib user32 ;
-  lib Bcrypt ;
-}
+lib ws2_32 ;
+lib shell32 ;
+lib Advapi32 ;
+lib Ntdll ;
+lib user32 ;
+lib Bcrypt ;
 
 project : requirements
+  <library>/boost/process//boost_process
   <define>BOOST_ASIO_NO_DEPRECATED
   <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS
   <toolset>msvc:<define>_CRT_SECURE_NO_DEPRECATE
@@ -32,21 +28,19 @@ project : requirements
   <os>NT,<toolset>gcc:<library>ws2_32
   <os>NT,<toolset>gcc:<library>Bcrypt
   <define>BOOST_PROCESS_V2_SEPARATE_COMPILATION=1
+  <library>/boost/test//included
 ;
 
 import testing ;
-
-alias filesystem   : /boost//filesystem : <link>static ;
 
 exe target : target.cpp :
     <warnings>off <target-os>windows:<source>shell32
                   <target-os>windows:<source>Ntdll
     ;
 
-lib test_impl : test_impl.cpp filesystem /boost//process :
+lib test_impl : test_impl.cpp /boost/process//boost_process :
         <define>BOOST_PROCESS_V2_SEPARATE_COMPILATION=1
         <define>BOOST_TEST_IGNORE_SIGCHLD=1
-        <link>static
         ;
 
 test-suite standalone :

--- a/test/v2/process.cpp
+++ b/test/v2/process.cpp
@@ -9,9 +9,6 @@
 #define BOOST_ALL_NO_LIB 1
 #endif // !defined(BOOST_ALL_NO_LIB)
 
-#if defined(BOOST_FILESYSTEM_DYN_LINK)
-#undef BOOST_FILESYSTEM_DYN_LINK
-#endif
 #define BOOST_TEST_IGNORE_SIGCHLD 1
 
 #if  true //defined(BOOST_POSIX_API)
@@ -55,9 +52,9 @@ BOOST_AUTO_TEST_CASE(exit_code_sync)
 {
     using boost::unit_test::framework::master_test_suite;
     const auto pth =  master_test_suite().argv[1];
-    
+
     boost::asio::io_context ctx;
-    
+
     BOOST_CHECK_EQUAL(bpv::process(ctx, pth, {"exit-code", "0"}).wait(), 0);
     BOOST_CHECK_EQUAL(bpv::execute(bpv::process(ctx, pth, {"exit-code", "1"})), 1);
     std::vector<std::string> args = {"exit-code", "2"};
@@ -85,7 +82,7 @@ BOOST_AUTO_TEST_CASE(exit_code_async)
 
     int called = 0;
     printf("Setting up processes\n");
-    
+
     bpv::process proc1(ctx, pth, {"exit-code", "0"});
     bpv::process proc3(ctx, pth, {"exit-code", "2"});
     bpv::process proc4(ctx, pth, {"exit-code", "42"});
@@ -200,7 +197,7 @@ BOOST_AUTO_TEST_CASE(print_args_out)
 {
   using boost::unit_test::framework::master_test_suite;
   const auto pth =  master_test_suite().argv[1];
-  
+
   asio::io_context ctx;
 
   asio::readable_pipe rp{ctx};
@@ -296,7 +293,7 @@ BOOST_AUTO_TEST_CASE(echo_file)
 {
   using boost::unit_test::framework::master_test_suite;
   const auto pth =  master_test_suite().argv[1];
-  
+
   asio::io_context ctx;
 
   asio::readable_pipe rp{ctx};
@@ -476,7 +473,7 @@ BOOST_AUTO_TEST_CASE(environment)
 
   sub_env.push_back("FOOBAR=FOO-BAR");
   BOOST_CHECK_EQUAL("FOO-BAR", read_env("FOOBAR", bpv::process_environment{sub_env}));
-  
+
   sub_env.push_back("XYZ=ZYX");
   auto itr = std::find_if(sub_env.begin(), sub_env.end(), [](const bpv::environment::key_value_pair & kv) {return kv.key() == bpv::environment::key("PATH");});
   path += static_cast<char>(bpv::environment::delimiter);
@@ -511,7 +508,7 @@ BOOST_AUTO_TEST_CASE(exit_code_as_error)
   bpv::process proc3(ctx, pth, {"sleep", "2000"});
 
   int called = 0;
-  
+
   proc3.terminate();
 
 

--- a/test/v2/windows.cpp
+++ b/test/v2/windows.cpp
@@ -9,10 +9,6 @@
 #define BOOST_ALL_NO_LIB 1
 #endif // !defined(BOOST_ALL_NO_LIB)
 
-#if defined(BOOST_FILESYSTEM_DYN_LINK)
-#undef BOOST_FILESYSTEM_DYN_LINK
-#endif
-
 // Test that header file is self-contained.
 #include <boost/process/v2/process.hpp>
 


### PR DESCRIPTION
* Make the library modular usable.

* Switch to library requirements instead of source. As source puts extra source in install targets.

* Add requires-b2 check to top-level build file.

* Add missing test deps.

* Bump B2 require to 5.2

* Fix duplicate def of boost.process.fs feature.

* Add missing boost_test dependency.

* Move inter-lib dependencies to a project variable and into the build targets.

* Switch to /boost/test//included target for header only mode of Boost.Test.

* Adjust doc build to avoid boost-root references.

* Update build deps.

* Fix link and build of deps.